### PR TITLE
Fix NoSuchKey for local proxy URLs (strip leading /), and delete with correct client

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -126,7 +126,7 @@ export default class ObsidianS3 extends Plugin {
 			new Notice(`[${id}] Found ${doDelete.length} un-used objects, deleting...`);
 			for (let y = 0; y < doDelete.length; y++) {
 				console.log(`[${id}] S3: Deleting ${doDelete[y].name}`);
-				await this.s3.removeObject(doDelete[y].name);
+				await s3.removeObject(doDelete[y].name);
 			}
 			new Notice(`[${id}] Deleted ${doDelete.length} objects.`);
 			new Notice(`[${id}] Current bucket size ${prettyBytes(await s3.getBucketSize())}`);

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -42,7 +42,9 @@ export class S3Server {
 		if (!req.url) return console.log("ERROR: URL is undefined");
 		const url = new URL(`${this.url}${req.url}`);
 		const ext = parseExt(url.pathname);
-		const path = decodeURI(url.pathname);
+		// S3 object keys don't start with '/', but URL pathnames do.
+		// If we pass a leading '/' through to S3, we'll get NoSuchKey.
+		const path = decodeURI(url.pathname).replace(/^\/+/, '');
 		console.log(`fetching: ${url.toString()}`);
 		const client = url.searchParams.get("client");
 		const bucket = url.searchParams.get("bucket");


### PR DESCRIPTION
This PR fixes a `NoSuchKey` retrieval error when the plugin serves attachments via the local HTTP proxy. The proxy request path begins with `/`, but S3 object keys do not, resulting in a 404.

In particular, when an attachment is referenced as `http://localhost:4998/files/image-...png?...`, `url.pathname` is `/files/image-...png`. S3 expects the key `files/image-...png` (no leading `/`). Normalizing the pathname fixes the mismatch and prevents `NoSuchKey`.

While making this change, I also fixed two related issues found during build + review:
- `clearUnusedCallback()` could delete objects using the active client instead of the client being iterated (risk of deleting from the wrong bucket/client).
- A couple small TypeScript issues prevented `npm run build` from succeeding on `master`.

I'm a typescript noob and I used AI to help me fix this issue. I've tested this locally in my vault and confirmed that it works.